### PR TITLE
[depthcamera] fixes compute median depth (inverted axes)

### DIFF
--- a/emioapi/_depthcamera.py
+++ b/emioapi/_depthcamera.py
@@ -38,7 +38,7 @@ def compute_median_depth(contour, depth_image):
     # Fills the area bounded by the contours if thickness < 0
     cv.drawContours(image, contours=[contour], contourIdx=0, color=255, thickness=-1)
     points = np.where(image == 255)
-    depth_values = depth_image[points[0], points[1]].flatten()
+    depth_values = depth_image[points[1], points[0]].flatten()
     valid_depth_values = depth_values[depth_values > 0]
     if len(valid_depth_values) > 0:
         return np.median(valid_depth_values)


### PR DESCRIPTION
This should fix the error described in #18 

> Error log:
IndexError: index 635 is out of bounds for axis 0 with size 480

To do before merging:
- [x] test 
