### PR TITLE
Set default fps to 30 because of hub incompatibilities

### DIFF
--- a/emioapi/_depthcamera.py
+++ b/emioapi/_depthcamera.py
@@ -61,7 +61,7 @@ class DepthCamera:
     rsconfig = None
     pipeline = None
     point_cloud = None
-    fps = 60
+    fps = 30
     intr = None
     profile = None
     initialized = False

--- a/emioapi/emiocamera.py
+++ b/emioapi/emiocamera.py
@@ -314,7 +314,7 @@ class EmioCamera:
     def fps(self) -> int:
         """
         Get the current stream framerate of the camera in frames per second.
-        Default is 60 fps.
+        Default is 30 fps.
 
         You have to set the fps _before_ calling the `open` method.
 
@@ -328,7 +328,7 @@ class EmioCamera:
         """
         Set the camera framerate.
         Available framerates are 30, 60 and 90 fps.
-        Default is 60 fps.
+        Default is 30 fps.
         """
         self._camera.set_fps(value)
 


### PR DESCRIPTION
Issue with new hub forces to default the fps to 30. 
More than 30 fps might lead to camera not working.