### PR TITLE
Update tracking property of DepthCamera

### DIFF
--- a/emioapi/_depthcamera.py
+++ b/emioapi/_depthcamera.py
@@ -66,7 +66,7 @@ class DepthCamera:
     compute_point_cloud = False
     position_estimator: PositionEstimation = None
     parameter = {}
-    tracking = True
+    tracking = False
     trackers_pos = []
     maskWindow = None
     frameWindow = None

--- a/emioapi/emiocamera.py
+++ b/emioapi/emiocamera.py
@@ -159,6 +159,7 @@ class EmioCamera:
             value: bool: The new tracking status.
         """
         self._tracking = value
+        self._camera.tracking = self._tracking
 
     @property
     def compute_point_cloud(self) -> bool:

--- a/emioapi/emiomotors.py
+++ b/emioapi/emiomotors.py
@@ -55,8 +55,6 @@ class EmioMotors:
     ###### METHODS ######
     #####################
 
-
-
     def __init__(self):
         self._lock = Lock()
         if not self._initialized:


### PR DESCRIPTION
The `tracking` variable of `DepthCamera` was not updated when changing it from `EmioCamera`.

Fixes issue #34. 

Tested and works.