### PR TITLE
[Calibration] fix camera does not calibrate if video feed is off

### DIFF
--- a/emioapi/_depthcamera.py
+++ b/emioapi/_depthcamera.py
@@ -267,7 +267,8 @@ class DepthCamera:
                 _, color_image, depth_image, _ = self.get_frame()
                 success = self.position_estimator.calibrate(color_image, depth_image, first, calibration_window)
                 first = success if not first else first
-                self.rootWindow.update()
+                if self.show_video_feed:
+                    self.rootWindow.update()
 
         if success:
             self.position_estimator.compute_camera_to_simulation_transform()


### PR DESCRIPTION
fix a crash when attempting to calibrate without the video feed